### PR TITLE
Fix incorrect service name in S90hostapd

### DIFF
--- a/board/raspberrypi/rootfs_overlay/etc/init.d/S90hostapd
+++ b/board/raspberrypi/rootfs_overlay/etc/init.d/S90hostapd
@@ -7,7 +7,7 @@ case "$1" in
                 [ $? = 0 ] && echo "OK" || echo "FAIL"
                 ;;
         stop)
-                printf "Stopping dnsmasq: "
+                printf "Stopping hostapd: "
                 start-stop-daemon -K -q -x /usr/sbin/hostapd
                 [ $? = 0 ] && echo "OK" || echo "FAIL"
                 ;;


### PR DESCRIPTION
I noticed this error in [the blog post (Part 4)](https://www.thirtythreeforty.net/posts/2020/03/mastering-embedded-linux-part-4-adding-features/) and I just saw the same mistake here so I thought I would let you know here :)